### PR TITLE
Add polyfill URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ overhead.
 
 * Initial Discussion: https://github.com/tc39/ecma402/issues/188
 
+Polyfill: [@formatjs/intl-datetimeformat](https://www.npmjs.com/package/@formatjs/intl-datetimeformat)
+
 ## Proposal
 
 Add `formatRange(date1, date2)` and `formatRangeToParts(date1, date2)` to


### PR DESCRIPTION
As of `@formatjs/intl-datetimeformat@2.8.0` (https://github.com/formatjs/formatjs/commit/a5290ad276ef66bf66c8e33f040f5b94f6556620) we now support `formatRange`